### PR TITLE
install stringi from source and clean redundant installations

### DIFF
--- a/.github/workflows/update-covid19-testdir.yml
+++ b/.github/workflows/update-covid19-testdir.yml
@@ -49,9 +49,9 @@ jobs:
 
       - name: Installing packages
         run: |
-          Rscript -e "install.packages('remotes', type = 'source')"
+          Rscript -e "install.packages(c('remotes', 'stringi'), type = 'source')"
           Rscript -e "remotes::install_github('finddx/shinyfind')"
-          Rscript -e 'install.packages(c("readr", "dplyr", "tidyr", "fuzzyjoin", "countrycode"), repos = "https://packagemanager.rstudio.com/cran/__linux__/focal/latest")'
+          Rscript -e 'install.packages(c("fuzzyjoin", "countrycode"), repos = "https://packagemanager.rstudio.com/cran/__linux__/focal/latest")'
 
       - name: Running update scripts
         run: |

--- a/.github/workflows/update-ebola.yml
+++ b/.github/workflows/update-ebola.yml
@@ -49,9 +49,9 @@ jobs:
 
       - name: Installing packages
         run: |
-          Rscript -e "install.packages('remotes', type = 'source')"
+          Rscript -e "install.packages(c('remotes', 'stringi'), type = 'source')"
           Rscript -e "remotes::install_github('finddx/shinyfind')"
-          Rscript -e 'install.packages(c("readr", "dplyr", "tidyr", "fuzzyjoin", "countrycode"), repos = "https://packagemanager.rstudio.com/cran/__linux__/focal/latest")'
+          Rscript -e 'install.packages(c("fuzzyjoin", "countrycode"), repos = "https://packagemanager.rstudio.com/cran/__linux__/focal/latest")'
 
       - name: Running update scripts
         run: |

--- a/.github/workflows/update-eqa-covid-testdir.yml
+++ b/.github/workflows/update-eqa-covid-testdir.yml
@@ -49,9 +49,9 @@ jobs:
 
       - name: Installing packages
         run: |
-          Rscript -e "install.packages('remotes', type = 'source')"
+          Rscript -e "install.packages(c('remotes', 'stringi'), type = 'source')"
           Rscript -e "remotes::install_github('finddx/shinyfind')"
-          Rscript -e 'install.packages(c("readr", "dplyr", "tidyr", "fuzzyjoin", "countrycode"), repos = "https://packagemanager.rstudio.com/cran/__linux__/focal/latest")'
+          Rscript -e 'install.packages(c("fuzzyjoin", "countrycode"), repos = "https://packagemanager.rstudio.com/cran/__linux__/focal/latest")'
 
       - name: Running update scripts
         run: |

--- a/.github/workflows/update-monkeypox.yml
+++ b/.github/workflows/update-monkeypox.yml
@@ -49,9 +49,9 @@ jobs:
 
       - name: Installing packages
         run: |
-          Rscript -e "install.packages('remotes', type = 'source')"
+          Rscript -e "install.packages(c('remotes', 'stringi'), type = 'source')"
           Rscript -e "remotes::install_github('finddx/shinyfind')"
-          Rscript -e 'install.packages(c("readr", "dplyr", "tidyr", "fuzzyjoin", "countrycode"), repos = "https://packagemanager.rstudio.com/cran/__linux__/focal/latest")'
+          Rscript -e 'install.packages(c("fuzzyjoin", "countrycode"), repos = "https://packagemanager.rstudio.com/cran/__linux__/focal/latest")'
 
       - name: Running update scripts
         run: |


### PR DESCRIPTION
Fixes failing workflow for all diseases because `stringi` is installed from RSPM binaries instead of from source. https://github.com/finddx/FINDtestdirData/actions/runs/3506267014/jobs/5942469546